### PR TITLE
Add option to disable Firebase and use self-hosted database or local storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ PUBLIC_PAYPRO_PRO_MONTHLY=
 PUBLIC_PAYPRO_PRO_YEARLY=
 PUBLIC_PAYPRO_PORTAL=
 PUBLIC_PAYPRO_API_BASE_URL=
+
+# Configuration options for choosing between Firebase, MongoDB, or self-hosted database
+STORAGE_TYPE=firebase # Options: firebase, mongodb, selfhosted
+DATABASE_URL= # URL for self-hosted database or MongoDB

--- a/README.databases.md
+++ b/README.databases.md
@@ -1,0 +1,112 @@
+# Database Configuration for SlickGPT
+
+This document provides an overview of the different storage options available for SlickGPT, along with configuration instructions, setup examples, and security considerations.
+
+## Storage Options
+
+SlickGPT supports the following storage options:
+1. Firebase
+2. MongoDB
+3. Self-hosted Database
+4. Local Storage (IndexedDB)
+
+### 1. Firebase
+
+Firebase is a cloud-based platform that provides a real-time NoSQL database. It is suitable for applications that require real-time data synchronization and sharing.
+
+#### Configuration
+
+To use Firebase, set the following environment variables in your `.env` file:
+
+```
+STORAGE_TYPE=firebase
+FIREBASE_APIKEY=your_firebase_api_key
+FIREBASE_AUTHDOMAIN=your_firebase_auth_domain
+FIREBASE_DATABASEURL=your_firebase_database_url
+FIREBASE_PROJECTID=your_firebase_project_id
+FIREBASE_STORAGEBUCKET=your_firebase_storage_bucket
+FIREBASE_MESSAGINGSENDERID=your_firebase_messaging_sender_id
+FIREBASE_APPID=your_firebase_app_id
+```
+
+#### Setup Example
+
+1. Create a Firebase project in the Firebase Console.
+2. Obtain the necessary credentials and set them in the `.env` file as shown above.
+3. Ensure that the Firebase Realtime Database is enabled in your Firebase project.
+
+#### Security Considerations
+
+- Ensure that your Firebase credentials are kept secure and not exposed in the client-side code.
+- Use Firebase security rules to control access to your database.
+
+### 2. MongoDB
+
+MongoDB is a NoSQL database that stores data in JSON-like documents. It is suitable for users who prefer to manage their own database infrastructure.
+
+#### Configuration
+
+To use MongoDB, set the following environment variables in your `.env` file:
+
+```
+STORAGE_TYPE=mongodb
+DATABASE_URL=your_mongodb_connection_string
+```
+
+#### Setup Example
+
+1. Install MongoDB on your server or use a managed MongoDB service like MongoDB Atlas.
+2. Obtain the connection string for your MongoDB instance and set it in the `.env` file as shown above.
+3. Ensure that the MongoDB server is running and accessible from your application.
+
+#### Security Considerations
+
+- Use strong authentication and authorization mechanisms to secure access to your MongoDB database.
+- Ensure that your MongoDB connection string is kept secure and not exposed in the client-side code.
+- Regularly back up your MongoDB data to prevent data loss.
+
+### 3. Self-hosted Database
+
+A self-hosted database is suitable for users who prefer to use their own database infrastructure with a REST API. SlickGPT can interact with any self-hosted database that provides a REST API without knowing the backend details.
+
+#### Configuration
+
+To use a self-hosted database, set the following environment variables in your `.env` file:
+
+```
+STORAGE_TYPE=selfhosted
+DATABASE_URL=your_self_hosted_database_api_url
+```
+
+#### Setup Example
+
+1. Set up your self-hosted database and ensure it provides a REST API.
+2. Obtain the API URL for your self-hosted database and set it in the `.env` file as shown above.
+3. Ensure that the self-hosted database is running and accessible from your application.
+
+#### Security Considerations
+
+- Use strong authentication and authorization mechanisms to secure access to your self-hosted database.
+- Ensure that your self-hosted database API URL is kept secure and not exposed in the client-side code.
+- Regularly back up your self-hosted database data to prevent data loss.
+
+### 4. Local Storage (IndexedDB)
+
+IndexedDB is a client-side storage solution suitable for users running the application locally. It provides a way to store data persistently in the user's browser.
+
+#### Configuration
+
+To use IndexedDB, set the following environment variable in your `.env` file:
+
+```
+STORAGE_TYPE=local
+```
+
+#### Setup Example
+
+1. No additional setup is required for IndexedDB. It is automatically used when the `STORAGE_TYPE` is set to `local`.
+
+#### Security Considerations
+
+- Ensure that sensitive data is encrypted before storing it in IndexedDB.
+- Be aware that data stored in IndexedDB is accessible to the user and can be cleared by the user.

--- a/src/misc/firebase.ts
+++ b/src/misc/firebase.ts
@@ -9,6 +9,7 @@ import {
 	FIREBASE_MESSAGINGSENDERID,
 	FIREBASE_APPID
 } from '$env/static/private';
+import { STORAGE_TYPE } from '$env/static/public';
 import type { Chat, ChatMessage } from './shared';
 
 /**
@@ -21,29 +22,36 @@ const throwIfUnset = (name: string, value: any) => {
 	if (value == null) throw new Error(`${name} environment variable missing`);
 };
 
-throwIfUnset(FIREBASE_APIKEY, 'FIREBASE_APIKEY');
-throwIfUnset(FIREBASE_AUTHDOMAIN, 'FIREBASE_AUTHDOMAIN');
-throwIfUnset(FIREBASE_PROJECTID, 'FIREBASE_PROJECTID');
-throwIfUnset(FIREBASE_DATABASEURL, 'FIREBASE_DATABASEURL');
-throwIfUnset(FIREBASE_STORAGEBUCKET, 'FIREBASE_STORAGEBUCKET');
-throwIfUnset(FIREBASE_MESSAGINGSENDERID, 'FIREBASE_MESSAGINGSENDERID');
-throwIfUnset(FIREBASE_APPID, 'FIREBASE_APPID');
+if (STORAGE_TYPE === 'firebase') {
+	throwIfUnset(FIREBASE_APIKEY, 'FIREBASE_APIKEY');
+	throwIfUnset(FIREBASE_AUTHDOMAIN, 'FIREBASE_AUTHDOMAIN');
+	throwIfUnset(FIREBASE_PROJECTID, 'FIREBASE_PROJECTID');
+	throwIfUnset(FIREBASE_DATABASEURL, 'FIREBASE_DATABASEURL');
+	throwIfUnset(FIREBASE_STORAGEBUCKET, 'FIREBASE_STORAGEBUCKET');
+	throwIfUnset(FIREBASE_MESSAGINGSENDERID, 'FIREBASE_MESSAGINGSENDERID');
+	throwIfUnset(FIREBASE_APPID, 'FIREBASE_APPID');
 
-const firebaseConfig = {
-	apiKey: FIREBASE_APIKEY,
-	authDomain: FIREBASE_AUTHDOMAIN,
-	projectId: FIREBASE_PROJECTID,
-	storageBucket: FIREBASE_STORAGEBUCKET,
-	messagingSenderId: FIREBASE_MESSAGINGSENDERID,
-	appId: FIREBASE_APPID,
-	databaseURL: FIREBASE_DATABASEURL
-};
+	const firebaseConfig = {
+		apiKey: FIREBASE_APIKEY,
+		authDomain: FIREBASE_AUTHDOMAIN,
+		projectId: FIREBASE_PROJECTID,
+		storageBucket: FIREBASE_STORAGEBUCKET,
+		messagingSenderId: FIREBASE_MESSAGINGSENDERID,
+		appId: FIREBASE_APPID,
+		databaseURL: FIREBASE_DATABASEURL
+	};
 
-const app = initializeApp(firebaseConfig);
+	const app = initializeApp(firebaseConfig);
 
-export const db = getDatabase(app);
+	export const db = getDatabase(app);
+}
 
 export async function loadChatFromDb(slug: string) {
+	if (STORAGE_TYPE !== 'firebase') {
+		console.log('Firebase is disabled. Skipping loadChatFromDb.');
+		return null;
+	}
+
 	const response = (await get(ref(db, `sharedchats/${slug}`))).toJSON() as Chat;
 
 	// firebase stores array as objects like { 0: whatever, 1: whateverelse }

--- a/src/misc/mongodb.ts
+++ b/src/misc/mongodb.ts
@@ -1,0 +1,35 @@
+import { MongoClient } from 'mongodb';
+
+let client: MongoClient;
+
+export async function connectToMongoDB(uri: string) {
+  if (!client) {
+    client = new MongoClient(uri);
+    await client.connect();
+  }
+}
+
+export async function getMongoDBItem<T>(key: string): Promise<T | null> {
+  const db = client.db();
+  const collection = db.collection('sharedchats');
+  const item = await collection.findOne({ key });
+  return item ? (item.value as T) : null;
+}
+
+export async function setMongoDBItem<T>(key: string, value: T): Promise<void> {
+  const db = client.db();
+  const collection = db.collection('sharedchats');
+  await collection.updateOne({ key }, { $set: { value } }, { upsert: true });
+}
+
+export async function removeMongoDBItem(key: string): Promise<void> {
+  const db = client.db();
+  const collection = db.collection('sharedchats');
+  await collection.deleteOne({ key });
+}
+
+export async function clearMongoDB(): Promise<void> {
+  const db = client.db();
+  const collection = db.collection('sharedchats');
+  await collection.deleteMany({});
+}

--- a/src/misc/shared.ts
+++ b/src/misc/shared.ts
@@ -25,6 +25,7 @@ import {
 	PUBLIC_OPENAI_API_URL
 } from '$env/static/public';
 import { AuthService } from './authService';
+import storageService from './storageService';
 
 export interface ChatContent {
 	type: 'text' | 'image_url';
@@ -255,4 +256,16 @@ export function showToast(
 		action
 	};
 	toastStore.trigger(toast);
+}
+
+export async function saveChat(slug: string, chat: Chat) {
+	await storageService.setItem(slug, chat);
+}
+
+export async function loadChat(slug: string): Promise<Chat | null> {
+	return await storageService.getItem<Chat>(slug);
+}
+
+export async function deleteChat(slug: string): Promise<boolean> {
+	return await storageService.removeItem(slug);
 }

--- a/src/misc/storageService.ts
+++ b/src/misc/storageService.ts
@@ -1,4 +1,8 @@
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb';
+import { DATABASE_URL, STORAGE_TYPE } from '$env/static/public';
+import { db, loadChatFromDb } from '$misc/firebase';
+import { ref, set, update } from 'firebase/database';
+import { connectToMongoDB, getMongoDBItem, setMongoDBItem, removeMongoDBItem, clearMongoDB } from '$misc/mongodb';
 
 interface StorageService {
 	getItem<T>(key: string): Promise<T | null>;
@@ -123,15 +127,169 @@ class InMemoryStorageService implements StorageService {
 	}
 }
 
+class SelfHostedStorageService implements StorageService {
+	private baseUrl: string;
+
+	constructor(baseUrl: string) {
+		this.baseUrl = baseUrl;
+	}
+
+	async getItem<T>(key: string): Promise<T | null> {
+		try {
+			const response = await fetch(`${this.baseUrl}/${key}`);
+			if (!response.ok) {
+				throw new Error('Failed to fetch item');
+			}
+			return await response.json();
+		} catch (error) {
+			console.error('Error in getItem:', error);
+			return null;
+		}
+	}
+
+	async setItem<T>(key: string, value: T): Promise<void> {
+		try {
+			const response = await fetch(`${this.baseUrl}/${key}`, {
+				method: 'PUT',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify(value)
+			});
+			if (!response.ok) {
+				throw new Error('Failed to set item');
+			}
+		} catch (error) {
+			console.error('Error in setItem:', error);
+		}
+	}
+
+	async removeItem(key: string): Promise<boolean> {
+		try {
+			const response = await fetch(`${this.baseUrl}/${key}`, {
+				method: 'DELETE'
+			});
+			if (!response.ok) {
+				throw new Error('Failed to remove item');
+			}
+			return true;
+		} catch (error) {
+			console.error('Error in removeItem:', error);
+			return false;
+		}
+	}
+
+	async clear(): Promise<void> {
+		try {
+			const response = await fetch(`${this.baseUrl}/clear`, {
+				method: 'POST'
+			});
+			if (!response.ok) {
+				throw new Error('Failed to clear items');
+			}
+		} catch (error) {
+			console.error('Error in clear:', error);
+		}
+	}
+}
+
+class FirebaseStorageService implements StorageService {
+	async getItem<T>(key: string): Promise<T | null> {
+		try {
+			const response = await loadChatFromDb(key);
+			return response as T;
+		} catch (error) {
+			console.error('Error in getItem:', error);
+			return null;
+		}
+	}
+
+	async setItem<T>(key: string, value: T): Promise<void> {
+		try {
+			await set(ref(db, `sharedchats/${key}`), value);
+		} catch (error) {
+			console.error('Error in setItem:', error);
+		}
+	}
+
+	async removeItem(key: string): Promise<boolean> {
+		try {
+			await update(ref(db), { [`sharedchats/${key}`]: null });
+			return true;
+		} catch (error) {
+			console.error('Error in removeItem:', error);
+			return false;
+		}
+	}
+
+	async clear(): Promise<void> {
+		try {
+			// Implement clear logic if needed
+		} catch (error) {
+			console.error('Error in clear:', error);
+		}
+	}
+}
+
+class MongoDBStorageService implements StorageService {
+	async getItem<T>(key: string): Promise<T | null> {
+		try {
+			return await getMongoDBItem<T>(key);
+		} catch (error) {
+			console.error('Error in getItem:', error);
+			return null;
+		}
+	}
+
+	async setItem<T>(key: string, value: T): Promise<void> {
+		try {
+			await setMongoDBItem(key, value);
+		} catch (error) {
+			console.error('Error in setItem:', error);
+		}
+	}
+
+	async removeItem(key: string): Promise<boolean> {
+		try {
+			await removeMongoDBItem(key);
+			return true;
+		} catch (error) {
+			console.error('Error in removeItem:', error);
+			return false;
+		}
+	}
+
+	async clear(): Promise<void> {
+		try {
+			await clearMongoDB();
+		} catch (error) {
+			console.error('Error in clear:', error);
+		}
+	}
+}
+
 const createStorageService = async (): Promise<StorageService> => {
-	if (typeof window !== 'undefined' && 'indexedDB' in window) {
-		const idbService = new IdbStorageService();
-
-		// migrate old chat to indexedDb
-		await idbService.migrateLocalStorageToIndexedDB();
-		await idbService.initDb();
-
-		return idbService;
+	switch (STORAGE_TYPE) {
+		case 'self-hosted':
+			if (DATABASE_URL) {
+				return new SelfHostedStorageService(DATABASE_URL);
+			}
+			break;
+		case 'firebase':
+			return new FirebaseStorageService();
+		case 'mongodb':
+			await connectToMongoDB(DATABASE_URL);
+			return new MongoDBStorageService();
+		case 'local':
+			if (typeof window !== 'undefined' && 'indexedDB' in window) {
+				const idbService = new IdbStorageService();
+				await idbService.migrateLocalStorageToIndexedDB();
+				await idbService.initDb();
+				return idbService;
+			}
+			break;
+		default:
+			return new InMemoryStorageService();
 	}
 	return new InMemoryStorageService();
 };

--- a/src/routes/api/share/+server.ts
+++ b/src/routes/api/share/+server.ts
@@ -1,11 +1,10 @@
 import { error } from '@sveltejs/kit';
 import type { Config } from '@sveltejs/adapter-vercel';
 import type { RequestHandler } from './$types';
-import { ref, set, update } from 'firebase/database';
 import { generateSlug } from 'random-word-slugs';
-import { db, loadChatFromDb } from '$misc/firebase';
 import type { Chat } from '$misc/shared';
 import { respondToClient, throwIfUnset, getErrorMessage } from '$misc/error';
+import storageService from '$misc/storageService';
 
 // this tells Vercel to run this function as https://vercel.com/docs/concepts/functions/edge-functions
 export const config: Config = {
@@ -18,7 +17,7 @@ export const GET: RequestHandler = async ({ url }) => {
 		throw new Error('missing URL param: slug');
 	}
 
-	const chat = await loadChatFromDb(slug);
+	const chat = await storageService.getItem<Chat>(slug);
 	if (!chat) {
 		throw error(404, 'Chat not found');
 	}
@@ -42,7 +41,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		// The updateToken is like a "password" for later edits
 		let updateToken: string = chat.updateToken || generateSlug();
 
-		const savedDocument = await loadChatFromDb(slug);
+		const savedDocument = await storageService.getItem<Chat>(slug);
 		// already saved
 		if (savedDocument) {
 			// updateToken is wrong or this slug has already been saved ("duplicate ID")
@@ -59,8 +58,8 @@ export const POST: RequestHandler = async ({ request }) => {
 			updateToken
 		};
 
-		// save to firebase
-		await set(ref(db, `sharedchats/${slug}`), documentToSave);
+		// save to storage service
+		await storageService.setItem(slug, documentToSave);
 
 		return respondToClient({ slug, updateToken });
 	} catch (err) {
@@ -76,11 +75,10 @@ export const DELETE: RequestHandler = async ({ request }) => {
 
 		if (!Object.keys(requestData)?.length) throw new Error('No docs to delete provided');
 
-		const updates: Record<string, any> = {};
 		const deleted: string[] = [];
 
 		for (const [slug, updateToken] of Object.entries(requestData)) {
-			const savedDocument = await loadChatFromDb(slug);
+			const savedDocument = await storageService.getItem<Chat>(slug);
 			// already saved
 			if (savedDocument) {
 				// updateToken is wrong
@@ -88,14 +86,9 @@ export const DELETE: RequestHandler = async ({ request }) => {
 					// in this case we just create a new share
 					throw new Error(`Wrong update token for chat ${slug}. Cannot delete.`);
 				}
-				updates[`sharedchats/${slug}`] = null;
+				await storageService.removeItem(slug);
 				deleted.push(slug);
 			}
-		}
-
-		if (deleted.length) {
-			// delete in firebase
-			await update(ref(db), updates);
 		}
 
 		return respondToClient({ deleted });


### PR DESCRIPTION
Add support for disabling Firebase and using alternative storage options.

* **.env.example**: Add configuration options for choosing between Firebase, MongoDB, or self-hosted database.
* **src/misc/firebase.ts**: Handle the new configuration options to bypass Firebase if necessary.
* **src/routes/api/share/+server.ts**: Use the new storage service instead of directly interacting with Firebase.
* **src/misc/storageService.ts**: Extend to support both self-hosted databases and local storage for chat sharing. Use a `switch` statement in the `createStorageService` function for cleaner code.
* **src/misc/shared.ts**: Use the new storage service for chat-related operations.
* **src/misc/mongodb.ts**: Add MongoDB storage service implementation.
* **README.databases.md**: Update to reflect the removal of the `memory` option and provide configuration instructions for different storage options.

